### PR TITLE
Expose as promise and observable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ npm install kernelspecs
 ## Usage
 
 ```javascript
-> require('kernelspecs').kernelSpecs().then(console.log)
+> require('kernelspecs').asPromise().then(console.log)
 Promise { <pending> }
 > { babel:
    { files:


### PR DESCRIPTION
Removes the stutter inherent in `require('kernelspecs').kernelSpecs().then()`

Now it's

`require('kernelspecs').asPromise()`
