### PR TITLE
Allow searching for one kernelspec by name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
-const findAll = require('./lib/traverse').findAll;
+const traverse = require('./lib/traverse');
+
+const findAll = traverse.findAll;
+const find = traverse.find;
 
 module.exports = {
   findAll,
+  find,
 };

--- a/lib/traverse.js
+++ b/lib/traverse.js
@@ -49,6 +49,33 @@ function getKernelInfos(directory) {
   );
 }
 
+
+function find(kernelName) {
+  return jp.dataDirs({ withSysPrefix: true }).then(dirs => {
+
+    const kernelInfos = dirs.map(dir => ({
+      name: kernelName,
+      resourceDir: path.join(dir, 'kernels', kernelName),
+    }))
+
+    return extractKernelResources(kernelInfos);
+  });
+}
+
+function extractKernelResources(kernelInfos) {
+  return Promise.all(kernelInfos
+    .filter(a => a) // remove null/undefined kernelInfo
+    .reduce((a, b) => a.concat(b), []) // flatten the results into one array
+    .map(a => getKernelResources(a).catch(() => {})) // convert kernelInfo -> kernelResources and ignore errors
+  ).then(kernelResources => kernelResources
+    .filter(a => a) // remove null/undefined kernelResources
+    .reduce((kernels, kernel) => {
+      kernels[kernel.name] = kernel;
+      return kernels;
+    }, {})
+  )
+}
+
 /**
  * Get an array of kernelResources objects for the host environment
  * This matches the Jupyter notebook API for kernelspecs exactly
@@ -59,21 +86,12 @@ function findAll() {
     return Promise.all(dirs
       // get kernel infos for each directory and ignore errors
       .map(dir => getKernelInfos(path.join(dir, 'kernels')).catch(() => {}))
-    ).then(kernelInfos => Promise.all(kernelInfos
-      .filter(a => a) // remove null/undefined kernelInfo
-      .reduce((a, b) => a.concat(b), []) // flatten the results into one array
-      .map(a => getKernelResources(a).catch(() => {})) // convert kernelInfo -> kernelResources and ignore errors
-    )).then(kernelResources => kernelResources
-      .filter(a => a) // remove null/undefined kernelResources
-      .reduce((kernels, kernel) => {
-        kernels[kernel.name] = kernel;
-        return kernels;
-      }, {})
-    );
+    ).then(extractKernelResources)
   });
 }
 
 module.exports = {
+  find,
   findAll,
   getKernelInfos,
   getKernelResources,

--- a/lib/traverse.js
+++ b/lib/traverse.js
@@ -49,7 +49,11 @@ function getKernelInfos(directory) {
   );
 }
 
-
+/**
+ * find a kernel by name
+ * @param  {string} kernelName the kernel to locate
+ * @return {Object} kernelResource object
+ */
 function find(kernelName) {
   return jp.dataDirs({ withSysPrefix: true }).then(dirs => {
 
@@ -59,7 +63,7 @@ function find(kernelName) {
     }))
 
     return extractKernelResources(kernelInfos);
-  });
+  }).then(kernelResource => kernelResource[kernelName])
 }
 
 function extractKernelResources(kernelInfos) {
@@ -79,7 +83,7 @@ function extractKernelResources(kernelInfos) {
 /**
  * Get an array of kernelResources objects for the host environment
  * This matches the Jupyter notebook API for kernelspecs exactly
- * @return {Promise<Object[]>} Promise for an array of kernelResources objects
+ * @return {Promise<Object<string,kernelResource>} Promise for an array of kernelResources objects
  */
 function findAll() {
   return jp.dataDirs({ withSysPrefix: true }).then(dirs => {


### PR DESCRIPTION
This provides one more public facing interface, `find` which lets you find a kernel by name `find('python2')`. This was done in support of https://github.com/nteract/nteract/pull/1264.

This module in general is due for some refactoring soon, I noticed that it doesn't enforce priority on kernels with the same name across separate jupyter data directories.