### PR TITLE
upgrade jupyter paths and devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "homepage": "https://github.com/nteract/kernelspecs#readme",
   "dependencies": {
-    "jupyter-paths": "^1.0.2"
+    "jupyter-paths": "^2.0.0"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
-    "mocha": "^3.2.0"
+    "chai": "^4.1.1",
+    "mocha": "^3.5.0"
   }
 }


### PR DESCRIPTION
Getting this fixed up so we can make releases on all the `jupyter-paths` dependent packages.