### PR TITLE
Change resources_dir to resource_dir

### DIFF
--- a/lib/traverse.js
+++ b/lib/traverse.js
@@ -29,7 +29,7 @@ function getKernelResources(kernelInfo) {
     return promisify(fs.readFile, [path.join(kernelInfo.resourceDir, 'kernel.json')]).then(data => ({
       name: kernelInfo.name,
       files: files.map(x => path.join(kernelInfo.resourceDir, x)),
-      resources_dir: kernelInfo.resourceDir, // eslint-disable-line camelcase
+      resource_dir: kernelInfo.resourceDir, // eslint-disable-line camelcase
       spec: JSON.parse(data),
     }));
   });

--- a/test/traverse_spec.js
+++ b/test/traverse_spec.js
@@ -10,7 +10,7 @@ describe('findAll', () => {
       const defaultKernel = kernelspecs.python2 || kernelspecs.python3;
 
       expect(defaultKernel).to.have.property('spec');
-      expect(defaultKernel).to.have.property('resources_dir');
+      expect(defaultKernel).to.have.property('resource_dir');
 
       const spec = defaultKernel.spec;
 


### PR DESCRIPTION
According to `jupyter kernelspec list --json`, it should be `resource_dir`, not `resources_dir`.

Fixes #25 